### PR TITLE
Fix pixel coordinates bug

### DIFF
--- a/dkm/models/dkm.py
+++ b/dkm/models/dkm.py
@@ -646,8 +646,8 @@ class RegressionMatcher(nn.Module):
     
     def to_pixel_coordinates(self, matches, H_A, W_A, H_B, W_B):
         kpts_A, kpts_B = matches[...,:2], matches[...,2:]
-        kpts_A = torch.stack((W_A/2 * (kpts_A[...,0]+1), H_A/2 * (kpts_A[...,1]+1)),axis=-1)
-        kpts_B = torch.stack((W_B/2 * (kpts_B[...,0]+1), H_B/2 * (kpts_B[...,1]+1)),axis=-1)
+        kpts_A = torch.stack((W_A/2 * (kpts_A[...,0]+1)-.5, H_A/2 * (kpts_A[...,1]+1)-.5),axis=-1)
+        kpts_B = torch.stack((W_B/2 * (kpts_B[...,0]+1)-.5, H_B/2 * (kpts_B[...,1]+1)-.5),axis=-1)
         return kpts_A, kpts_B
     
     def match(


### PR DESCRIPTION
Thank you for your great work and for open-sourcing your code!

I believe there is a small bug in the `to_pixel_coordinates` function. Specifically, consider a square image with side length 1024. Since `align_corners=False` is used throughout the code, where pixels are treated as squares of side length 1, -1 and 1 in the normalized grid correspond to 0 and 1024, respectively. 

You correctly accounted for this in the code via `torch.linspace(-1 + 1 / h, 1 - 1 / h, h)` and `torch.linspace(-1 + 1 / w, 1 - 1 / w, w)`, i.e., `-1 + 1 / h` corresponds to 0.5 and `1 - 1 / h` corresponds to 1023.5. However, when converting these normalized coordinates back to _pixels_, they must be shifted left by 0.5 pixels after rescaling.